### PR TITLE
Fix integer overflow issue when describing ticket

### DIFF
--- a/Rubeus/lib/krb_structures/KrbCredInfo.cs
+++ b/Rubeus/lib/krb_structures/KrbCredInfo.cs
@@ -52,9 +52,9 @@ namespace Rubeus
                         pname = new PrincipalName(s.Sub[0]);
                         break;
                     case 3:
-                        UInt32 temp = Convert.ToUInt32(s.Sub[0].GetInteger());
+                        UInt64 temp = Convert.ToUInt64(s.Sub[0].GetInteger());
                         byte[] tempBytes = BitConverter.GetBytes(temp);
-                        flags = (Interop.TicketFlags)BitConverter.ToInt32(tempBytes, 0);
+                        flags = (Interop.TicketFlags)BitConverter.ToInt64(tempBytes, 0);
                         break;
                     case 4:
                         authtime = s.Sub[0].GetTime();


### PR DESCRIPTION
Fix integer overflow issue when describing ticket. 
Changed UInt32 to UInt64

![image](https://github.com/koztkozt/Rubeus/assets/96878659/79a0e7cc-0990-43c8-8aca-6165a41202f1)
